### PR TITLE
Fixes #1 - refactor constant classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.joshualeepenn</groupId>
     <artifactId>utilities</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/com/joshualeepenn/utilities/constants/Separator.java
+++ b/src/main/java/com/joshualeepenn/utilities/constants/Separator.java
@@ -1,9 +1,9 @@
-package com.joshualeepenn.utilities;
+package com.joshualeepenn.utilities.constants;
 
 /**
  * Static whitespace chars useful for lists, separators, etc.
  */
-public class Separators {
+public class Separator {
 
     // Prototypical
     public static final String COMMA = ",";

--- a/src/main/java/com/joshualeepenn/utilities/constants/Whitespace.java
+++ b/src/main/java/com/joshualeepenn/utilities/constants/Whitespace.java
@@ -1,4 +1,4 @@
-package com.joshualeepenn.utilities;
+package com.joshualeepenn.utilities.constants;
 
 /**
  * Static whitespace chars useful for lists, separators, etc.


### PR DESCRIPTION
- Added a "constants" package and moved constants classes there
- renamed "Separators" class to "Separator" for proper naming convention